### PR TITLE
Added notepad support for edit & take command

### DIFF
--- a/Takeep.Cli/Program.cs
+++ b/Takeep.Cli/Program.cs
@@ -45,15 +45,20 @@ var takeCopy = new Option<bool> ("--copy", "Copies the item's text to clipboard"
 takeCopy.Arity = ArgumentArity.ZeroOrOne;
 takeCopy.AddAlias ("-c");
 
+var takeNotepad = new Option<bool> ("--open", "Opens the item's content in notepad");
+takeNotepad.Arity = ArgumentArity.ZeroOrOne;
+takeNotepad.AddAlias ("-o");
+
 var takeCommand = new Command (
 	"take",
 	"Takes (finds) an Item")
 {
 	takeName,
-	takeCopy
+	takeCopy,
+	takeNotepad
 };
 
-takeCommand.SetHandler ((string take, bool copy) =>
+takeCommand.SetHandler ((string take, bool copy, bool notepad) =>
 {
 	if (take == null)
 	{
@@ -67,7 +72,7 @@ takeCommand.SetHandler ((string take, bool copy) =>
 	{
 		try
 		{
-			TakeepXml.Take (take, copy);
+			TakeepXml.Take (take, copy, notepad);
 		}
 		catch (Exception exeption)
 		{
@@ -75,7 +80,7 @@ takeCommand.SetHandler ((string take, bool copy) =>
 		}
 	}
 
-}, takeName, takeCopy);
+}, takeName, takeCopy, takeNotepad);
 
 #endregion
 

--- a/Takeep.Cli/Program.cs
+++ b/Takeep.Cli/Program.cs
@@ -139,34 +139,39 @@ listCommand.SetHandler (() =>
 #region Edit Command
 
 var editName = new Option<string> ("--name", "Gets the name of the item");
-var editContent = new Option<string> ("--text", "Gets the content of the keep item");
+editName.AddAlias ("-n");
+editName.Arity = ArgumentArity.ExactlyOne;
 
-keepName.Arity = ArgumentArity.ExactlyOne;
+var editContent = new Option<string> ("--text", "Gets the content of the keep item");
+editContent.AddAlias ("-t");
 editContent.Arity = ArgumentArity.ExactlyOne;
 
-editName.AddAlias ("-n");
-editContent.AddAlias ("-t");
+var editNotepad = new Option<bool> ("--open", "Opens the item in notepad");
+editNotepad.Arity = ArgumentArity.ZeroOrOne;
+editNotepad.AddAlias ("-o");
+
 
 var editCommand = new Command (
 	"edit",
 	"Edits an item's content (not name)")
 {
 	editName,
-	editContent
+	editContent,
+	editNotepad
 };
 
-editCommand.SetHandler ((string name, string content) =>
+editCommand.SetHandler ((string name, string content, bool notepad) =>
 {
 	try
 	{
-		TakeepXml.Edit (new Item { Name = name, Content = content });
+		TakeepXml.Edit (new Item { Name = name, Content = content }, notepad);
 	}
 	catch (Exception exception)
 	{
 		HandleException (exception);
 	}
 
-}, editName, editContent);
+}, editName, editContent, editNotepad);
 
 #endregion
 

--- a/Takeep.Core/TakeepXml.cs
+++ b/Takeep.Core/TakeepXml.cs
@@ -330,7 +330,8 @@ namespace Takeep.Core
 			string filePath = directory + "/ITEM_CONTENT";
 			File.Delete (filePath);
 
-			File.WriteAllText (filePath, GetItem(name).Content);
+			File.WriteAllText (filePath, $"/# This is the content of item \"{name}\":{Environment.NewLine}");
+			File.AppendAllText (filePath, GetItem(name).Content);
 
 			FileInfo fileInfo = new (filePath);
 			File.SetAttributes (filePath, FileAttributes.Hidden);
@@ -359,10 +360,6 @@ namespace Takeep.Core
 
 				if (checkProcess.HasExited)
 				{
-					Console.ForegroundColor = ConsoleColor.Red;
-					Console.WriteLine ("Notepad was closed");
-					Console.ForegroundColor = ConsoleColor.White;
-
 					File.Delete (filePath);
 
 					return;


### PR DESCRIPTION
You can edit an item by notepad with this command:
`tkp edit -n test --open`

& You can take an item by notepad with this command:
`tkp take -n test --open`

Also, error interfaces & checks are improved